### PR TITLE
Add Jest test setup

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env']
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack",
-    "dev": "webpack server"
+    "dev": "webpack server",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -24,7 +25,9 @@
     "style-loader": "^3.3.2",
     "webpack": "^5.81.0",
     "webpack-cli": "^5.0.2",
-    "webpack-dev-server": "^4.13.3"
+    "webpack-dev-server": "^4.13.3",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.15.2",

--- a/src/js/assessment.js
+++ b/src/js/assessment.js
@@ -16,6 +16,7 @@ import {
   doc,
 } from "firebase/firestore";
 import { getAuth, onAuthStateChanged, signOut } from "firebase/auth";
+import { calculateScore } from "./utils";
 
 // Firebase configuration
 const firebaseConfig = {
@@ -246,23 +247,10 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     const userId = auth.currentUser.uid;
-    let score = 0;
-    const improvementAreas = [];
-
-    // Calculate score and determine improvement areas
-    for (const questionId in responses) {
-      const response = responses[questionId];
-
-      if (response === "Yes") {
-        score += 2; // Full score for "Yes"
-      } else if (response === "Partially") {
-        score += 1; // Partial score for "Partially"
-      } else if (response === "No") {
-        improvementAreas.push(questionId); // Log areas that need improvement
-      }
-    }
-
-    const normalizedScore = (score / (questions.length * 2)) * 100;
+    const { normalizedScore, improvementAreas } = calculateScore(
+      responses,
+      questions.length
+    );
 
     try {
       await addDoc(collection(db, "assessments"), {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,18 @@
+export function calculateScore(responses, totalQuestions) {
+  let score = 0;
+  const improvementAreas = [];
+
+  for (const questionId in responses) {
+    const response = responses[questionId];
+    if (response === 'Yes') {
+      score += 2;
+    } else if (response === 'Partially') {
+      score += 1;
+    } else if (response === 'No') {
+      improvementAreas.push(questionId);
+    }
+  }
+
+  const normalizedScore = (score / (totalQuestions * 2)) * 100;
+  return { normalizedScore, improvementAreas };
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,15 @@
+import { calculateScore } from '../src/js/utils';
+
+describe('calculateScore', () => {
+  test('computes score and improvement areas', () => {
+    const responses = {
+      q1: 'Yes',
+      q2: 'No',
+      q3: 'Partially',
+      q4: 'No'
+    };
+    const { normalizedScore, improvementAreas } = calculateScore(responses, 4);
+    expect(normalizedScore).toBeCloseTo(((2 + 0 + 1 + 0) / 8) * 100);
+    expect(improvementAreas).toEqual(['q2', 'q4']);
+  });
+});


### PR DESCRIPTION
## Summary
- provide Jest config and Babel preset
- add scoring helper and use it in `assessment.js`
- include initial unit test for scoring logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fd2936ddc8320b652882d5afe52fe