### PR TITLE
feat: add secure admin creation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7,13 +7,38 @@
  * See a full list of supported triggers at https://firebase.google.com/docs/functions
  */
 
-const {onRequest} = require("firebase-functions/v2/https");
-const logger = require("firebase-functions/logger");
+const {onCall, HttpsError} = require("firebase-functions/v2/https");
+const admin = require("firebase-admin");
+const crypto = require("crypto");
 
-// Create and deploy your first functions
-// https://firebase.google.com/docs/functions/get-started
+admin.initializeApp();
 
-// exports.helloWorld = onRequest((request, response) => {
-//   logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+exports.createAdminUser = onCall(async (request) => {
+  const {email, name} = request.data;
+  if (!email || !name) {
+    throw new HttpsError("invalid-argument", "Email and name are required");
+  }
+  try {
+    const tempPassword = crypto
+        .randomBytes(12)
+        .toString("base64")
+        .slice(0, 16);
+
+    const userRecord = await admin.auth().createUser({
+      email,
+      password: tempPassword,
+    });
+
+    await admin.firestore().collection("admins").doc(userRecord.uid).set({
+      username: name,
+      email,
+      type: "admin",
+    });
+
+    await admin.auth().setCustomUserClaims(userRecord.uid, {admin: true});
+
+    return {uid: userRecord.uid};
+  } catch (error) {
+    throw new HttpsError("internal", error.message);
+  }
+});

--- a/src/js/adminmain.js
+++ b/src/js/adminmain.js
@@ -1,4 +1,7 @@
 const main = require("./main.js");
+const { getFunctions, httpsCallable } = require("firebase/functions");
+const functions = getFunctions();
+const createAdminUser = httpsCallable(functions, "createAdminUser");
 let userData;
 
 main.onAuthStateChanged(main.auth, (user) => {
@@ -53,29 +56,22 @@ if (newAdminBtn) {
 }
 
 if (newAdminForm) {
-  newAdminForm.addEventListener("submit", (e) => {
+  newAdminForm.addEventListener("submit", async (e) => {
     e.preventDefault();
     const adminName = newAdminForm.querySelector("#adminName").value;
     const adminEmail = newAdminForm.querySelector("#adminEmail").value;
 
-    // Create a new admin user with email and default password
-    main
-      .createUserWithEmailAndPassword(main.auth2, adminEmail, "defaultPassword")
-      .then((cred) => {
-        return main.setDoc(main.doc(main.db, "admins", cred.user.uid), {
-          username: adminName,
-          email: adminEmail,
-          type: "admin",
-        });
-      })
-      .then(() => {
-        alert("New admin created successfully.");
-        newAdminForm.reset();
-        newAdminForm.classList.remove("show");
-      })
-      .catch((error) => {
-        console.error("Error creating new admin:", error);
-        alert(error.message);
-      });
+    try {
+      await createAdminUser({ name: adminName, email: adminEmail });
+      await main.sendPasswordResetEmail(main.auth2, adminEmail);
+      alert(
+        "New admin created successfully. A password reset email has been sent."
+      );
+      newAdminForm.reset();
+      newAdminForm.classList.remove("show");
+    } catch (error) {
+      console.error("Error creating new admin:", error);
+      alert(error.message);
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add cloud function to create admin accounts with random temporary passwords
- update admin panel to call function and send password reset email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm --prefix functions test` *(fails: Missing script "test")*
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd92da2288320b0503317082d6ada